### PR TITLE
Issue 18: Add 1PasswordX to the extension whitelist

### DIFF
--- a/data/whitelist.json
+++ b/data/whitelist.json
@@ -5,6 +5,10 @@
             "description": "1Password"
         },
         {
+            "id": "aeblfdkhhhdcdjpifhhbdiojplfjncoa",
+            "description": "1PasswordX"
+        },
+        {
             "id": "ajopnjidmegmdimjlfnijceegpefgped",
             "description": "BetterTTV"
         },


### PR DESCRIPTION
Fix #18 

Adding 1PasswordX: https://chrome.google.com/webstore/detail/1password-x-%E2%80%93-password-ma/aeblfdkhhhdcdjpifhhbdiojplfjncoa