### PR TITLE
Fix 21: Add Tab Defrag to the extension whitelist

### DIFF
--- a/data/whitelist.json
+++ b/data/whitelist.json
@@ -97,6 +97,10 @@
             "description": "Brave HTTPS Everywhere Updater"
         },
         {
+            "id": "dfeliknbmopheafjaelmilpgfmfjiopl",
+            "description": "Tab Defrag"
+        },
+        {
             "id": "naccapggpomhlhoifnlebfoocegenbol",
             "description": "Test ID: Brave Default Ad Block Updater"
         },


### PR DESCRIPTION
fix #21 

Sec-Review: https://github.com/brave/security/issues/50 (Approved)