### PR TITLE
Support building on node v12+

### DIFF
--- a/node_addon/EWParserWrap.cc
+++ b/node_addon/EWParserWrap.cc
@@ -51,7 +51,8 @@ namespace EWParserWrap {
     NODE_SET_PROTOTYPE_METHOD(tpl, "cleanup", CEWParserWrap::Cleanup);
 
     constructor.Reset(isolate, tpl->GetFunction(isolate->GetCurrentContext()).ToLocalChecked());
-    exports->Set(String::NewFromUtf8(isolate, "CEWParser", NewStringType::kNormal).ToLocalChecked(),
+    exports->Set(isolate->GetCurrentContext(),
+                 String::NewFromUtf8(isolate, "CEWParser", NewStringType::kNormal).ToLocalChecked(),
                  tpl->GetFunction(isolate->GetCurrentContext()).ToLocalChecked());
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -587,9 +587,8 @@
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "hashset-cpp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/hashset-cpp/-/hashset-cpp-2.2.1.tgz",
-      "integrity": "sha512-pO16ApkT0SEtXmCy9FgcwwPnTUbdRzL000gcpOtJyIY3OOSYvh4eQaZdYjlU+Y1AOzy3am6msgHZZ5Yok19aLw=="
+      "version": "github:bbondy/hashset-cpp#e283e264477c68227bb394ff8eaa7dd44d57578f",
+      "from": "github:bbondy/hashset-cpp#e283e264477c68227bb394ff8eaa7dd44d57578f"
     },
     "he": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/brave/extension-whitelist#readme",
   "dependencies": {
-    "hashset-cpp": "^2.2.1",
+    "hashset-cpp": "github:bbondy/hashset-cpp#e283e264477c68227bb394ff8eaa7dd44d57578f",
     "mkdirp": "^1.0.3",
     "node-gyp": "^5.0.3"
   },


### PR DESCRIPTION
Thanks to https://github.com/bbondy/hashset-cpp/pull/5 and an additional small change, I'm able to get this building on more recent Node versions (including the current 15.6.x version).