### PR TITLE
Suppress scary warning when installing Tor's Snowflake extension

### DIFF
--- a/data/whitelist.json
+++ b/data/whitelist.json
@@ -129,6 +129,10 @@
             "description": "HTTPS Everywhere"
         },
         {
+            "id": "mafpmfcccpbjnhfhjnllmmalhifmlcie",
+            "description": "Snowflake"
+        },
+        {
             "id": "naccapggpomhlhoifnlebfoocegenbol",
             "description": "Test ID: Brave Default Ad Block Updater"
         },


### PR DESCRIPTION
https://snowflake.torproject.org/
https://chrome.google.com/webstore/detail/snowflake/mafpmfcccpbjnhfhjnllmmalhifmlcie